### PR TITLE
use dtsi

### DIFF
--- a/package/boot/uboot-envtools/files/ramips
+++ b/package/boot/uboot-envtools/files/ramips
@@ -36,7 +36,7 @@ zbt-wg2626)
 xiaomi,mir3p|\
 xiaomi,mir3g|\
 xiaomi,redmi-router-ac2100|\
-xiaomi,r2100)
+xiaomi,mi-router-ac2100)
 	ubootenv_add_uci_config "/dev/mtd1" "0x0" "0x1000" "0x20000"
 	;;
 esac

--- a/target/linux/ramips/base-files/etc/board.d/01_leds
+++ b/target/linux/ramips/base-files/etc/board.d/01_leds
@@ -401,7 +401,7 @@ xiaomi,mir3p)
 	ucidef_set_led_switch "lan2-amber" "LAN2 (amber)" "$boardname:amber:lan2" "switch0" "0x04" "0x08"
 	ucidef_set_led_switch "lan3-amber" "LAN3 (amber)" "$boardname:amber:lan3" "switch0" "0x08" "0x08"
 	;;
-xiaomi,r2100)
+xiaomi,mi-router-ac2100)
 	ucidef_set_led_switch "wan-yellow"  "WAN (yellow)"  "$boardname:yellow:wan"  "switch0" "0x01" "0x01"
 	ucidef_set_led_switch "wan-blue"  "WAN (blue)"  "$boardname:blue:wan"  "switch0" "0x01"
 	;;

--- a/target/linux/ramips/base-files/etc/board.d/02_network
+++ b/target/linux/ramips/base-files/etc/board.d/02_network
@@ -463,11 +463,8 @@ ramips_setup_interfaces()
 		ucidef_add_switch "switch0" \
 			"2:lan:2" "3:lan:1" "1:wan" "6t@eth0"
 		;;
-	xiaomi,redmi-router-ac2100)
-		ucidef_add_switch "switch0" \
-			"2:lan" "3:lan" "4:lan" "0:wan" "6t@eth0"
-		;;
-	xiaomi,r2100)
+	xiaomi,redmi-router-ac2100|\
+	xiaomi,mi-router-ac2100)
 		ucidef_add_switch "switch0" \
 			"2:lan" "3:lan" "4:lan" "0:wan" "6t@eth0"
 		;;

--- a/target/linux/ramips/base-files/lib/upgrade/platform.sh
+++ b/target/linux/ramips/base-files/lib/upgrade/platform.sh
@@ -63,7 +63,7 @@ platform_do_upgrade() {
 	xiaomi,mir3g|\
 	xiaomi,mir3p|\
 	xiaomi,redmi-router-ac2100|\
-	xiaomi,r2100)
+	xiaomi,mi-router-ac2100)
 		nand_do_upgrade "$1"
 		;;
 	tplink,c50-v4)

--- a/target/linux/ramips/dts/mi-router-ac2100.dts
+++ b/target/linux/ramips/dts/mi-router-ac2100.dts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-2.0-or-later OR MIT
+/dts-v1/;
+
+#include "xiaomi-router-ac2100.dtsi"
+
+/ {
+	compatible = "xiaomi,mi-router-ac2100", "mediatek,mt7621-soc";
+	model = "Xiaomi Mi Router AC2100";
+
+	aliases {
+		led-boot = &led_status_yellow;
+		led-failsafe = &led_status_yellow;
+		led-running = &led_status_blue;
+		led-upgrade = &led_status_blue;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		led_status_yellow: status_yellow {
+			label = "mi-router-ac2100:yellow:status";
+			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
+		};
+
+		led_status_blue: status_blue {
+			label = "mi-router-ac2100:blue:status";
+			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
+		};
+
+
+		wan_yellow {
+			label = "mi-router-ac2100:yellow:wan";
+			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_blue {
+			label = "mi-router-ac2100:blue:wan";
+			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
+		};
+
+		wan_amber {
+			label = "mi-router-ac2100:amber:wan";
+			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
+		};
+		
+		lan1_amber {
+			label = "mi-router-ac2100:amber:lan1";
+			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
+		};
+
+		lan2_amber {
+			label = "mi-router-ac2100:amber:lan2";
+			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
+		};
+		
+		lan3_amber {
+			label = "mi-router-ac2100:amber:lan3";
+			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
+		};
+	};
+};

--- a/target/linux/ramips/dts/redmi-router-ac2100.dts
+++ b/target/linux/ramips/dts/redmi-router-ac2100.dts
@@ -1,10 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later OR MIT
 /dts-v1/;
 
-#include "mt7621.dtsi"
-
-#include <dt-bindings/gpio/gpio.h>
-#include <dt-bindings/input/input.h>
+#include "xiaomi-router-ac2100.dtsi"
 
 / {
 	compatible = "xiaomi,redmi-router-ac2100", "mediatek,mt7621-soc";
@@ -15,10 +12,6 @@
 		led-failsafe = &led_status_amber;
 		led-running = &led_status_white;
 		led-upgrade = &led_status_white;
-	};
-
-	chosen {
-		bootargs = "console=ttyS0,115200n8";
 	};
 
 	leds {
@@ -42,120 +35,6 @@
 		wan_white {
 			label = "redmi-router-ac2100:white:wan";
 			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
-		};
-	};
-
-	keys {
-		compatible = "gpio-keys";
-
-		reset {
-			label = "reset";
-			gpios = <&gpio0 18 GPIO_ACTIVE_LOW>;
-			linux,code = <KEY_RESTART>;
-		};
-	};
-
-};
-
-
-&nand {
-	status = "okay";
-
-	partitions {
-		compatible = "fixed-partitions";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		partition@0 {
-			label = "Bootloader";
-			reg = <0x0 0x80000>;
-			read-only;
-		};
-
-		partition@80000 {
-			label = "Config";
-			reg = <0x80000 0x40000>;
-		};
-
-		partition@c0000 {
-			label = "Bdata";
-			reg = <0xc0000 0x40000>;
-			read-only;
-		};
-
-		factory: partition@100000 {
-			label = "factory";
-			reg = <0x100000 0x40000>;
-			read-only;
-		};
-
-		partition@140000 {
-			label = "crash";
-			reg = <0x140000 0x40000>;
-		};
-
-		partition@180000 {
-			label = "crash_syslog";
-			reg = <0x180000 0x40000>;
-		};
-
-		partition@1c0000 {
-			label = "reserved0";
-			reg = <0x1c0000 0x40000>;
-			read-only;
-		};
-
-		/* We keep stock xiaomi firmware (kernel0) here */
-		partition@200000 {
-			label = "kernel_stock";
-			reg = <0x200000 0x400000>;
-		};
-
-		partition@600000 {
-			label = "kernel";
-			reg = <0x600000 0x400000>;
-		};
-
-		partition@a00000 {
-			label = "ubi";
-			reg = <0xa00000 0x7580000>;
-		};
-	};
-};
-
-&pcie {
-	status = "okay";
-};
-
-/* XXX swapped these around ... */
-&pcie0 {
-	wifi@0,0 {
-		compatible = "pci14c3,7615";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x8000>;
-		ieee80211-freq-limit = <5000000 6000000>;
-	};
-};
-
-&pcie1 {
-	wifi@0,0 {
-		compatible = "pci14c3,7603";
-		reg = <0x0000 0 0 0 0>;
-		mediatek,mtd-eeprom = <&factory 0x0000>;
-		ieee80211-freq-limit = <2400000 2500000>;
-	};
-};
-
-&ethernet {
-	mtd-mac-address = <&factory 0xe000>;
-	mediatek,portmap = "wllll";
-};
-
-&pinctrl {
-	state_default: pinctrl0 {
-		gpio {
-			ralink,group = "uart2", "uart3", "wdt";
-			ralink,function = "gpio";
 		};
 	};
 };

--- a/target/linux/ramips/dts/xiaomi-router-ac2100.dtsi
+++ b/target/linux/ramips/dts/xiaomi-router-ac2100.dtsi
@@ -7,63 +7,10 @@
 #include <dt-bindings/input/input.h>
 
 / {
-	compatible = "xiaomi,r2100", "mediatek,mt7621-soc";
-	model = "Xiaomi Mi AC2100";
-
-	aliases {
-		led-boot = &led_status_yellow;
-		led-failsafe = &led_status_yellow;
-		led-running = &led_status_blue;
-		led-upgrade = &led_status_blue;
-	};
+	compatible = "mediatek,mt7621-soc";
 
 	chosen {
 		bootargs = "console=ttyS0,115200n8";
-	};
-
-	leds {
-		compatible = "gpio-leds";
-
-		led_status_yellow: status_yellow {
-			label = "r2100:yellow:status";
-			gpios = <&gpio0 10 GPIO_ACTIVE_LOW>;
-		};
-
-		led_status_blue: status_blue {
-			label = "r2100:blue:status";
-			gpios = <&gpio0 12 GPIO_ACTIVE_LOW>;
-		};
-
-
-		wan_yellow {
-			label = "r2100:yellow:wan";
-			gpios = <&gpio0 6 GPIO_ACTIVE_LOW>;
-		};
-
-		wan_blue {
-			label = "r2100:blue:wan";
-			gpios = <&gpio0 8 GPIO_ACTIVE_LOW>;
-		};
-
-		wan_amber {
-			label = "r2100:amber:wan";
-			gpios = <&gpio0 14 GPIO_ACTIVE_LOW>;
-		};
-		
-		lan1_amber {
-			label = "r2100:amber:lan1";
-			gpios = <&gpio0 13 GPIO_ACTIVE_LOW>;
-		};
-
-		lan2_amber {
-			label = "r2100:amber:lan2";
-			gpios = <&gpio0 16 GPIO_ACTIVE_LOW>;
-		};
-		
-		lan3_amber {
-			label = "r2100:amber:lan3";
-			gpios = <&gpio0 15 GPIO_ACTIVE_LOW>;
-		};
 	};
 
 	keys {
@@ -148,7 +95,6 @@
 	status = "okay";
 };
 
-/* XXX swapped these around ... */
 &pcie0 {
 	wifi@0,0 {
 		compatible = "pci14c3,7615";

--- a/target/linux/ramips/image/mt7621.mk
+++ b/target/linux/ramips/image/mt7621.mk
@@ -595,8 +595,8 @@ define Device/xiaomi_redmi-router-ac2100
 endef
 TARGET_DEVICES += xiaomi_redmi-router-ac2100
 
-define Device/xiaomi_r2100
-  DTS := r2100
+define Device/xiaomi_mi-router-ac2100
+  DTS := mi-router-ac2100
   BLOCKSIZE := 128k
   PAGESIZE := 2048
   KERNEL_SIZE := 4096k
@@ -606,10 +606,10 @@ define Device/xiaomi_r2100
   IMAGE/kernel1.bin := append-kernel
   IMAGE/rootfs0.bin := append-ubi | check-size
   IMAGE/sysupgrade.bin := sysupgrade-tar | append-metadata
-  DEVICE_TITLE := Xiaomi Mi AC2100
+  DEVICE_TITLE := Xiaomi Mi Router AC2100
   DEVICE_PACKAGES := kmod-mt7603 kmod-mt7615e wpad-basic uboot-envtools
 endef
-TARGET_DEVICES += xiaomi_r2100
+TARGET_DEVICES += xiaomi_mi-router-ac2100
 
 
 define Device/wndr3700v5


### PR DESCRIPTION
because `redmi-router-ac2100` and "the black one" are almost identical (apart from leds), lets use a common dtsi file for the common features.

also, maybe "mi-router-ac2100" is a better name than r2100? isn't that the official name?

https://www.aliexpress.com/item/4000904677761.html?spm=a2g0o.productlist.0.0.769454fcaqxpnf&algo_pvid=ec1fd0b4-3387-44e5-88ba-b548b5da8580&algo_expid=ec1fd0b4-3387-44e5-88ba-b548b5da8580-5&btsid=0b0a0ad815907517854111687e6065&ws_ab_test=searchweb0_0,searchweb201602_,searchweb201603_